### PR TITLE
britecore-mock-project to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.1
 - name: britecore-mock-project
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9


### PR DESCRIPTION
Promote britecore-mock-project to version 0.0.9