### PR TITLE
britecore-mock-project to 0.0.25

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: britecore-mock-project
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.24
+  version: 0.0.25


### PR DESCRIPTION
Promote britecore-mock-project to version 0.0.25