### PR TITLE
britecore-mock-project to 0.0.39

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: britecore-mock-project
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.38
+  version: 0.0.39
 - name: ko-node
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.11


### PR DESCRIPTION
Promote britecore-mock-project to version 0.0.39