### PR TITLE
britecore-mock-project to 0.0.52

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: britecore-mock-project
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.51
+  version: 0.0.52
 - name: ko-node
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12


### PR DESCRIPTION
Promote britecore-mock-project to version 0.0.52